### PR TITLE
Fix update with multiple where params and values

### DIFF
--- a/spec/interro_spec.cr
+++ b/spec/interro_spec.cr
@@ -138,6 +138,10 @@ struct UserQuery < Interro::QueryBuilder(User)
       .update(name: name)
   end
 
+  def change_name_and_email(user : User, name : String, email : String)
+    where(id: user.id, email: user.email).update(name: name, email: email)
+  end
+
   def with_id_in_kwargs(ids : Array(UUID))
     where id: ids.map { |id| Interro::Any.new(id) }
   end
@@ -498,8 +502,18 @@ describe Interro do
       users.size.should eq 1
 
       user = users.first
-      users.first.id.should eq created_users[1].id
-      users.first.name.should eq "Jamie"
+      user.id.should eq created_users[1].id
+      user.name.should eq "Jamie"
+    end
+
+    it "can update multiple fields" do
+      users = query.change_name_and_email(created_users[1], name: "Jamie", email: "jamie@example.com")
+      users.size.should eq 1
+
+      user = users.first
+      user.id.should eq created_users[1].id
+      user.name.should eq "Jamie"
+      user.email.should eq "jamie@example.com"
     end
 
     it "can update records with SQL expressions" do

--- a/src/interro.cr
+++ b/src/interro.cr
@@ -161,10 +161,12 @@ module Interro
     end
 
     private def sqlize(values : NamedTuple, where, to io) : Nil
-      values.each_with_index((where.try(&.values.size) || 0) + 1) do |key, value, index|
+      where_size = (where.try(&.values.size) || 0)
+      last_index = values.size + where_size
+      values.each_with_index(where_size + 1) do |key, value, index|
         key.to_s io
         io << " = $" << index
-        if index <= values.size
+        if index < last_index
           io << ", "
         end
       end


### PR DESCRIPTION
I encountered an issue where updating a record with multiple `where` clauses fails because it misses a comma after the values. 

```
STATEMENT:  UPDATE users SET name = $3email = $4 WHERE (id = $1) AND (email = $2) RETURNING users.id, users.email, users.name, users.deactivated_at, users.created_at, users.updated_at
```

```
  1) Interro Interro::QueryBuilder(T) can update multiple fields

       syntax error at or near "email" (PQ::PQError)
```

Tracked this down to `sqlize` where the index starts at the number of where clause values + 1 but is being compared against the number of param values rather than the number of param values and where clause values. 


