### PR TITLE
Fix SQL emitted for compound queries

### DIFF
--- a/spec/interro_spec.cr
+++ b/spec/interro_spec.cr
@@ -806,6 +806,15 @@ describe Interro do
       users.should_not contain excluded
     end
 
+    it "can limit compound queries" do
+      Array.new(2) { create_user(name: "Limit LHS") }
+      Array.new(2) { create_user(name: "Limit RHS") }
+
+      users = (query.with_name("Limit LHS") | query.with_name("Limit RHS")).first(3).to_a
+
+      users.size.should eq 3
+    end
+
     describe "subqueries" do
       it "queries on membership in a set" do
         included = create_user(email: "included-#{UUID.random}")

--- a/spec/interro_spec.cr
+++ b/spec/interro_spec.cr
@@ -806,6 +806,16 @@ describe Interro do
       users.should_not contain excluded
     end
 
+    it "can run INTERSECT queries" do
+      both = create_user(name: "Both")
+      only_lhs = create_user(name: "Both", email: "lhs-only-#{UUID.random}@example.com")
+
+      users = (query.with_name("Both") & query.with_id(both.id)).to_a
+
+      users.should contain both
+      users.should_not contain only_lhs
+    end
+
     it "can limit compound queries" do
       Array.new(2) { create_user(name: "Limit LHS") }
       Array.new(2) { create_user(name: "Limit RHS") }

--- a/src/query_builder.cr
+++ b/src/query_builder.cr
@@ -258,7 +258,7 @@ module Interro
     end
 
     def &(other : self) : CompoundQuery
-      CompoundQuery.new(self, "INTERSECTION", other, connection(CONFIG.read_db))
+      CompoundQuery.new(self, "INTERSECT", other, connection(CONFIG.read_db))
     end
 
     def -(other : self) : CompoundQuery

--- a/src/query_builder.cr
+++ b/src/query_builder.cr
@@ -1052,7 +1052,7 @@ module Interro
           str << ' ' << @combinator << ' '
           str << rhs
           if @limit
-            str << "LIMIT $" << (arg_count += 1)
+            str << " LIMIT $" << (arg_count += 1)
           end
         end
       end


### PR DESCRIPTION
Two small fixes, each with a regression spec:

- `first(n)` on a compound query emitted no space before `LIMIT`.
- The `&` combinator emitted `INTERSECTION`, which isn't a SQL keyword.

Both specs fail on master and pass with the fixes.